### PR TITLE
EN-1768 Add ability to provide encryption key directly (Python SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ storage = Storage(
 
 You can turn off encryption (not recommended). Set `encrypt` property to `false` if you want to do this.
 
-#### Encryption key
+#### Encryption key/secret
 
-`secret_key_accessor` is used to pass secret/secrets used for encryption.
+`secret_key_accessor` is used to pass a key or secret used for encryption.
 
 Note: even though SDK uses PBKDF2 to generate a cryptographically strong encryption key, you must make sure you provide a secret/password which follows modern security best practices and standards.
 
@@ -45,15 +45,19 @@ Note: even though SDK uses PBKDF2 to generate a cryptographically strong encrypt
 {
   secrets: [{
        secret: <string>,
-       version: <int>
+       version: <int>,   # Should be a positive integer
+	   isKey: <boolean>  # Should be True only for user-defined encryption keys
+    }
   }, ....],
   currentVersion: <int>,
 }
 ```
 
-`secrets_data` allows you to specify multiple keys which SDK will use for decryption based on the version of the secret used for encryption. Meanwhile SDK will encrypt only using secret that matches `currentVersion` provided in `secrets_data` object.
+`secrets_data` allows you to specify multiple keys/secrets which SDK will use for decryption based on the version of the key or secret used for encryption. Meanwhile SDK will encrypt only using key/secret that matches `currentVersion` provided in `secrets_data` object.
 
-This enables the flexibility required to support Key Rotation policies when secrets/keys need to be changed with time. SDK will encrypt data using newer secret while maintaining the ability to decrypt records encrypted with old secrets. SDK also provides a method for data migration which allows to re-encrypt data with the newest secret. For details please see `migrate` method.
+This enables the flexibility required to support Key Rotation policies when secrets/keys need to be changed with time. SDK will encrypt data using current secret/key while maintaining the ability to decrypt records encrypted with old keys/secrets. SDK also provides a method for data migration which allows to re-encrypt data with the newest key/secret. For details please see `migrate` method.
+
+SDK allows you to use custom encryption keys, instead of secrets. Please note that user-defined encryption key should be a 32-characters 'utf8' encoded string as required by AES-256 cryptographic algorithm.
 
 
 Here are some examples how you can use `SecretKeyAccessor`.

--- a/incountry/incountry_crypto.py
+++ b/incountry/incountry_crypto.py
@@ -14,7 +14,7 @@ class InCrypto:
     IV_LENGTH = 12  # Bytes
     AUTH_TAG_LENGTH = 16  # Bytes
     PBKDF2_ROUNDS = 10000
-    DERIVED_KEY_LENGTH = 32  # Bytes
+    KEY_LENGTH = 32  # Bytes
     PBKDF2_DIGEST = "sha512"
 
     ENC_VERSION = "2"
@@ -144,20 +144,20 @@ class InCrypto:
         return (decryptor.update(enc) + decryptor.finalize()).decode("utf8")
 
     def get_key(self, salt, key_version=None):
-        [secret, version] = self.secret_key_accessor.get_secret(version=key_version)
-        return [
+        [secret, version, is_key] = self.secret_key_accessor.get_secret(version=key_version)
+
+        if is_key:
+            return (secret.encode("utf8"), version)
+
+        return (
             hashlib.pbkdf2_hmac(
-                InCrypto.PBKDF2_DIGEST,
-                secret.encode("utf8"),
-                salt,
-                InCrypto.PBKDF2_ROUNDS,
-                InCrypto.DERIVED_KEY_LENGTH,
+                InCrypto.PBKDF2_DIGEST, secret.encode("utf8"), salt, InCrypto.PBKDF2_ROUNDS, InCrypto.KEY_LENGTH,
             ),
             version,
-        ]
+        )
 
     def get_current_secret_version(self):
-        [secret, version] = self.secret_key_accessor.get_secret()
+        [secret, version, is_key] = self.secret_key_accessor.get_secret()
         return version
 
     def hash(self, data):

--- a/incountry/secret_key_accessor.py
+++ b/incountry/secret_key_accessor.py
@@ -16,26 +16,28 @@ class SecretKeyAccessor:
 
     def get_secret(self, version=None):
         if version is not None and not isinstance(version, int):
-            raise SecretKeyAccessorException(
-                "Invalid secret version requested. Version should be of type `int`"
-            )
+            raise SecretKeyAccessorException("Invalid secret version requested. Version should be of type `int`")
 
         secrets_data = self._accessor_function()
 
         if isinstance(secrets_data, str):
-            return (secrets_data, SecretKeyAccessor.DEFAULT_VERSION)
+            return (secrets_data, SecretKeyAccessor.DEFAULT_VERSION, False)
 
         try:
             validate(instance=secrets_data, schema=secret_key_accessor_response_schema)
         except ValidationError as e:
             raise SecretKeyAccessorException("SecretKeyAccessor validation error") from e
 
+        from .incountry_crypto import InCrypto
+
         version_to_search = version if version is not None else secrets_data.get("currentVersion")
 
         for secret_data in secrets_data.get("secrets"):
             if secret_data.get("version") == version_to_search:
-                return (secret_data.get("secret"), version_to_search)
+                is_key = secret_data.get("isKey", False)
+                secret = secret_data.get("secret")
+                if is_key and len(secret) != InCrypto.KEY_LENGTH:
+                    raise SecretKeyAccessorException("Key should be 32-characters long")
+                return (secret, version_to_search, is_key)
 
-        raise SecretKeyAccessorException(
-            "Secret not found for version {}".format(version_to_search)
-        )
+        raise SecretKeyAccessorException("Secret not found for version {}".format(version_to_search))

--- a/incountry/validation.py
+++ b/incountry/validation.py
@@ -8,7 +8,11 @@ secret_key_accessor_response_schema = {
             "minItems": 1,
             "items": {
                 "type": "object",
-                "properties": {"secret": {"type": "string"}, "version": {"type": "number"}},
+                "properties": {
+                    "secret": {"type": "string"},
+                    "version": {"type": "number"},
+                    "isKey": {"type": "boolean"},
+                },
             },
         },
     },

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -81,6 +81,31 @@ def test_enc_dec(plaintext, secret_key_accessor):
 
 
 @pytest.mark.parametrize("plaintext", PLAINTEXTS)
+@pytest.mark.parametrize(
+    "secret_key_accessor",
+    [
+        SecretKeyAccessor(
+            lambda: {
+                "currentVersion": 1,
+                "secrets": [
+                    {"secret": "password0", "version": 0},
+                    {"secret": "12345678901234567890123456789012", "version": 1, "isKey": True},
+                ],
+            }
+        )
+    ],
+)
+@pytest.mark.happy_path
+def test_enc_dec_with_key(plaintext, secret_key_accessor):
+    cipher = InCrypto(secret_key_accessor)
+
+    [enc, *rest] = cipher.encrypt(plaintext)
+    dec = cipher.decrypt(enc)
+
+    assert plaintext == dec
+
+
+@pytest.mark.parametrize("plaintext", PLAINTEXTS)
 @pytest.mark.happy_path
 def test_enc_without_secret_key_accessor(plaintext):
     cipher = InCrypto()

--- a/tests/unit/test_secret_key_accessor.py
+++ b/tests/unit/test_secret_key_accessor.py
@@ -9,33 +9,45 @@ from incountry import SecretKeyAccessor, SecretKeyAccessorException
 @pytest.mark.happy_path
 def test_get_secret_old(password):
     secret_accessor = SecretKeyAccessor(lambda: password)
-    [secret, secret_version] = secret_accessor.get_secret()
+    [secret, secret_version, is_key] = secret_accessor.get_secret()
     assert secret == password
     assert secret_version == SecretKeyAccessor.DEFAULT_VERSION
+    assert is_key is False
 
 
 @pytest.mark.parametrize(
-    "keys_data, proper_version, proper_key",
+    "keys_data, proper_version, proper_key, proper_is_key",
     [
+        (
+            {
+                "currentVersion": 1,
+                "secrets": [{"secret": "password0", "version": 0}, {"secret": "password1", "version": 1}],
+            },
+            1,
+            "password1",
+            False,
+        ),
         (
             {
                 "currentVersion": 1,
                 "secrets": [
                     {"secret": "password0", "version": 0},
-                    {"secret": "password1", "version": 1},
+                    {"secret": "12345678901234567890123456789012", "version": 1, "isKey": True},
                 ],
             },
             1,
-            "password1",
-        )
+            "12345678901234567890123456789012",
+            True,
+        ),
     ],
 )
 @pytest.mark.happy_path
-def test_get_secret(keys_data, proper_version, proper_key):
+def test_get_secret(keys_data, proper_version, proper_key, proper_is_key):
     secret_accessor = SecretKeyAccessor(lambda: keys_data)
-    [secret, secret_version] = secret_accessor.get_secret()
+    [secret, secret_version, is_key] = secret_accessor.get_secret()
     assert secret_version == proper_version
     assert secret == proper_key
+    assert is_key == proper_is_key
 
 
 @pytest.mark.error_path
@@ -46,20 +58,14 @@ def test_non_callable_accessor_function():
 @pytest.mark.error_path
 def test_incorrect_version_requested():
     secret_accessor = SecretKeyAccessor(lambda: "some password")
-    secret_accessor.get_secret.when.called_with("non int").should.have.raised(
-        SecretKeyAccessorException
-    )
+    secret_accessor.get_secret.when.called_with("non int").should.have.raised(SecretKeyAccessorException)
 
 
-@pytest.mark.parametrize(
-    "keys_data", [{"currentVersion": 1, "secrets": [{"secret": "password", "version": 1}]}]
-)
+@pytest.mark.parametrize("keys_data", [{"currentVersion": 1, "secrets": [{"secret": "password", "version": 1}]}])
 @pytest.mark.error_path
 def test_non_existing_version_requested(keys_data):
     secret_accessor = SecretKeyAccessor(lambda: keys_data)
-    secret_accessor.get_secret.when.called_with(version=0).should.have.raised(
-        SecretKeyAccessorException
-    )
+    secret_accessor.get_secret.when.called_with(version=0).should.have.raised(SecretKeyAccessorException)
 
 
 @pytest.mark.parametrize(
@@ -71,6 +77,9 @@ def test_non_existing_version_requested(keys_data):
         {"currentVersion": 1, "secrets": [{"secret": "password", "version": "1"}]},
         {"currentVersion": 1, "secrets": [{"secret": 1, "version": 1}]},
         {"currentVersion": 1, "secrets": []},
+        {"currentVersion": 1, "secrets": [{"secret": "password", "version": 1, "isKey": "yes"}]},
+        {"currentVersion": 1, "secrets": [{"secret": "password", "version": 1, "isKey": 1}]},
+        {"currentVersion": 1, "secrets": [{"secret": "password", "version": 1, "isKey": True}]},
     ],
 )
 @pytest.mark.error_path


### PR DESCRIPTION
[ENH] add the ability to pass encryption key instead of secret via SecretKeyAccessor
[ENH] update tests
[ENH] update README.md

Pull Request Checklist
======================

Please read this for our PR Culture:
------------------------------------
https://incountry.atlassian.net/wiki/spaces/ED/pages/46858869/Pull+requests+culture+Draft

Work relates to:
----------------
Link(s) to Jira Task/User Story/Bug/Epic:
- https://incountry.atlassian.net/browse/EN-1768

Code Quality (Before submitting PR)
------------
- [x] Ensure code compiles and passes Sonar Lint.
- [x] Do your best to ensure integration tests pass. If they don't then...
- [x] Remove, ignore, or mark pending any brittle tests.
- [x] Remove commented out code.

Target Release
--------------
- [x] Please put the target release vehicle this needs to be bundled with.
- [x] Did you increment the version? What is the new version?
